### PR TITLE
fix a few bugs

### DIFF
--- a/Feature2Vec.py
+++ b/Feature2Vec.py
@@ -223,7 +223,7 @@ class Feature2Vec(Norm):
         return np.flip([(self.id2concept[num], mat[0,num]) for num in np.argsort(mat[0,:])[-top:]])
     
     
-     def save(self, path):
+    def save(self, path):
         """Function to save all feature embeddings in a txt file"""
         with open(path, 'a') as f:
             for feature in self.features:

--- a/Norm.py
+++ b/Norm.py
@@ -22,7 +22,7 @@ class Norm:
         self.concepts = list(self.feature_matrix.index.values)
         self.concept2id, self.id2concept = self._build_index(self.concepts)
         
-        self.features = list(self.feature_matrix.columns[1:])
+        self.features = list(self.feature_matrix.columns)
         self.feature2id, self.id2feature = self._build_index(self.features)
         
         self.concept_features = {}
@@ -78,7 +78,7 @@ class Norm:
         """Function to load .csv file of property knowledge given a path"""
         # open feature_matrix data and read in using csv
         feature_matrix = pd.read_csv(path, index_col=[0])
-        data_matrix = feature_matrix.values[:, 1:]
+        data_matrix = feature_matrix.values
         
         return feature_matrix, data_matrix
     

--- a/Norm.py
+++ b/Norm.py
@@ -19,7 +19,7 @@ class Norm:
     def __init__(self, path):
         self.feature_matrix, self.data_matrix = self._load(path = path)
         
-        self.concepts = list(self.feature_matrix['Vectors'].values)
+        self.concepts = list(self.feature_matrix.index.values)
         self.concept2id, self.id2concept = self._build_index(self.concepts)
         
         self.features = list(self.feature_matrix.columns[1:])

--- a/utils.py
+++ b/utils.py
@@ -51,7 +51,7 @@ def build_norms(path, save_path):
     
     
     data_frame = pd.DataFrame(data_dict)
-    data_frame.to_csv(save)path
+    data_frame.to_csv(save_path)
 
 
 def neighbour_score(concept_dict, model, top = 10):


### PR DESCRIPTION
This fixes two typos.

Furthermore, this fixes a mistake when building the vocabulary of the model. When reading the `cslb_feature_matrix.csv` file, the first column is used as the index for the Pandas DataFrame, instead of a regular column.